### PR TITLE
Add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,11 @@ Arguments:
 
   window: option for windowing audio using a variety of Matlab/Octave compatible filters found in the "signal" package
     ex: 'bartlett', 'blackman', 'hamming', 'hanning', 'triang'
+
+Requirements:
+
+  See requirements.txt for packages. Install them with the [requiRements R package](https://cran.r-project.org/web/packages/requiRements/index.html) or by hand.
+  
+  The author specified no minimum R version but experiments indicate that 3.6.1 is too old. 4.1.1 works like a charm, at least on Windows 10.
+  
+  Requirements documented by Helen Griffiths, Newcastle University IT Service.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Email: c.carignan@phonetik.uni-muenchen.de
 
 Institution: Institute of Phonetics and Speech Processing (IPS), Ludwig-Maximilians-Universität München, Munich, Germany
 
-Description:
+## Description
 
   Converts an audio file to a 3D spectrogram; (optionally) saves as a stereolithography (STL) file for 3D printing
 
-Arguments:
+## Arguments
 
   inputfile (required): filepath string associated with WAV audio file
 
@@ -31,7 +31,7 @@ Arguments:
   window: option for windowing audio using a variety of Matlab/Octave compatible filters found in the "signal" package
     ex: 'bartlett', 'blackman', 'hamming', 'hanning', 'triang'
 
-Requirements:
+## Requirements
 
   See requirements.txt for packages. Install them with the [requiRements R package](https://cran.r-project.org/web/packages/requiRements/index.html) or by hand.
   

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+rayshader
+dplyr
+tuneR
+matlab
+raster
+png
+signal
+magick


### PR DESCRIPTION
Requirements.txt benefits:
- No need to trawl through the screenful of runtime errors to find out which packages are needed, just look at the list.
- Enables use of [requiRements](https://cran.r-project.org/web/packages/requiRements/index.html) to install all dependencies in one go, facilitating the use of this function by people who are unfamiliar with R.

Also a cosmetic change to README.md to make it easier to read.